### PR TITLE
Fix for #10 google maps don't work

### DIFF
--- a/source/demo/showcase/Maps.html
+++ b/source/demo/showcase/Maps.html
@@ -4,7 +4,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
   <!-- load the Google Maps API -->
-  <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=false&language=en"></script>
+  <script type="text/javascript" src="https://maps.google.com/maps/api/js?sensor=false&language=en"></script>
 
   <!-- load the Leaflet API  -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.2/leaflet.css" />


### PR DESCRIPTION
According to [How to fix website with mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content/How_to_fix_website_with_mixed_content) I've just replaced http with https.  