### PR TITLE
Browser example http -> https

### DIFF
--- a/source/class/qxl/demobrowser/demo/showcase/Browser.js
+++ b/source/class/qxl/demobrowser/demo/showcase/Browser.js
@@ -94,7 +94,7 @@ qx.Class.define("qxl.demobrowser.demo.showcase.Browser", {
 
       this.txtUrl = new qx.ui.form.TextField().set({
         marginLeft: 1,
-        value: "http://qooxdoo.org",
+        value: "https://qooxdoo.org",
         padding: 2,
         alignY: "middle",
       });


### PR DESCRIPTION
Fixed error:
```
http://Mixed Content: The page at 'https://qooxdoo.org/qxl.demobrowser/#event~Event_Bubbling.html' was loaded over HTTPS, but requested an insecure frame 'http://qooxdoo.org/'. This request has been blocked; the content must be served over HTTPS.
```