### PR TITLE
Added support of mobile examples for gecko engine

### DIFF
--- a/source/class/qxl/demobrowser/demo/mobile/Fingers.js
+++ b/source/class/qxl/demobrowser/demo/mobile/Fingers.js
@@ -68,7 +68,7 @@ qx.Class.define("qxl.demobrowser.demo.mobile.Fingers", {
       var modernIe =
         engine == "mshtml" &&
         qx.core.Environment.get("browser.documentmode") > 10;
-      if (engine != "webkit" && !modernIe) {
+      if (engine != "webkit" && engine != "gecko" && !modernIe) {
         var warningLabelStyle = {
           color: "green",
           position: "absolute",
@@ -82,7 +82,7 @@ qx.Class.define("qxl.demobrowser.demo.mobile.Fingers", {
         root.add(label);
         label.setAttribute(
           "innerHTML",
-          "<b>This demo is intended for WebKit-based browsers and IE11+.</b>"
+          "<b>This demo is intended for WebKit-based, Gecko-based browsers and IE11+.</b>"
         );
         return;
       }

--- a/source/class/qxl/demobrowser/demo/mobile/PingPong.js
+++ b/source/class/qxl/demobrowser/demo/mobile/PingPong.js
@@ -80,7 +80,7 @@ qx.Class.define("qxl.demobrowser.demo.mobile.PingPong", {
       var modernIe =
         engine == "mshtml" &&
         qx.core.Environment.get("browser.documentmode") > 10;
-      if (engine != "webkit" && !modernIe) {
+      if (engine != "webkit" && engine != "gecko" && !modernIe) {
         var warningLabelStyle = {
           color: "green",
           position: "absolute",
@@ -94,7 +94,7 @@ qx.Class.define("qxl.demobrowser.demo.mobile.PingPong", {
         root.add(label);
         label.setAttribute(
           "innerHTML",
-          "<b>This demo is intended for WebKit-based browsers and IE11+.</b>"
+          "<b>This demo is intended for WebKit-based, Gecko-based browsers and IE11+.</b>"
         );
         return;
       }


### PR DESCRIPTION
I don't know why Gecko Engine has been excluded for mobile examples. Now Fingers and Ping Pong demos works also in Mozilla Firefox.